### PR TITLE
Support CEC active source command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,9 @@ To turn the TV on or of from another Module you need to send a notification.
 this.sendNotification('CECControl', 'on');
 this.sendNotification('CECControl', 'off');
 ```
+
+To make the CEC adapter the `as` active source (so the TV switches to the Raspberry Pi HDMI source after the TV is powered on).
+
+```javascript
+this.sendNotification('CECControl', 'as');
+```

--- a/node_helper.js
+++ b/node_helper.js
@@ -40,6 +40,10 @@ module.exports = NodeHelper.create({
 							self.turnOff(function() {
 								self.handleQueue();
 							});
+					case 'as':
+							self.activeSource(function() {
+								self.handleQueue();
+							});
 						break;
 				}
 			}
@@ -89,6 +93,19 @@ module.exports = NodeHelper.create({
 				return;
 			}
 		  self.sendSocketNotification('TV', 'off');
+			callback();
+		});
+	},
+
+	activeSource: function (callback) {
+		var self = this;
+
+		exec('echo "as" | cec-client ' + this.config.comport + ' -s -d 1', function (error, stdout, stderr) {
+			if (error) {
+				console.log(error);
+				return;
+			}
+			self.sendSocketNotification('TV', 'as');
 			callback();
 		});
 	},


### PR DESCRIPTION
Allow the magic mirror to switch TV inputs to itself.  I verified this works for CEC v1.4.
