### PR TITLE
Fix #9 and #10 and add customCmdOn/Off for more flexibility

### DIFF
--- a/MMM-CECControl.js
+++ b/MMM-CECControl.js
@@ -10,7 +10,9 @@ Module.register("MMM-CECControl",{
     comport: 'RPI',
     offOnStartup: true,
     xscreensaver: false,
-    vcgencmd: false
+    useCustomCmd: false,
+    customCmdOn: 'vcgencmd display_power 1',
+    customCmdOff: 'vcgencmd display_power 0'
   },
 
 	start: function() {

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ Config | Description
 --- | ---
 `comport` | Comport of your Raspberry Pi <br />**Default Value:** `RPI`
 `offOnStartup` | Turn the TV off if the Mirror start <br />**Default Value:** `true`
-`xscreensaver` | Turn xScreensaver off if TV turn on. You need to have `sudo apt-get install xscreensaver` installed.
-`vcgencmd` | Use vcgencmd instead of CEC. <br />**Default Value:** `false`
+`xscreensaver` | Turn xScreensaver off if TV turn on. You need to have xscreensaver installed (Run `sudo apt-get install xscreensaver` to install).
+`useCustomCmd` | Use custom commands for TV on / off instead of CEC.<br />**Default Value:** `false`
+`customCmdOn` | Custom command for turning the TV on.<br />**Default Value:** `vcgencmd display_power 1`
+`customCmdOff` | Custom command for turning the TV off.<br />**Default Value:** `vcgencmd display_power 0`
 
 ### Full configuration of the module
 
@@ -43,8 +45,12 @@ Config | Description
         offOnStartup: true,
         // Turn xScreensaver off if TV turn on
         xscreensaver: false,
-        // Use `vcgencmd` command instead of CEC which works better for monitors
-        vcgencmd: false
+        // Use customCmdOn and customCmdOff instead of CEC
+        useCustomCmd: false
+        // Custom command to run to turn TV on
+        customCmdOn: 'vcgencmd display_power 1'
+        // Custom command to run to turn TV off
+        customCmdOff: 'vcgencmd display_power 0'
     }
 }
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,5 @@
 {
   "name": "mmm-ceccontrol",
-  "version": "1.0.0",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "python-shell": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/python-shell/-/python-shell-1.0.7.tgz",
-      "integrity": "sha512-k6s27Uj5WEAxFLRKLFUvlDCm1GpkmAQ4vg9CASgqwbHqAM1d1x3nh3bzlBKgmRwNDeLlu0DP41CqwRZn1DKtuA=="
-    }
-  }
+  "version": "1.3",
+  "lockfileVersion": 1
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mmm-ceccontrol",
-  "version": "1.3",
+  "version": "1.4",
   "description": "Control TV",
   "main": "MMM-CECControl.js",
   "scripts": {
@@ -24,7 +24,4 @@
     "url": "https://github.com/nischi/MMM-CECControl/issues"
   },
   "homepage": "https://github.com/nischi/MMM-CECControl#readme",
-  "dependencies": {
-    "python-shell": "^1.0.7"
-  }
 }


### PR DESCRIPTION
See the new README. There's now `useCustomCmd` instead of `vcgencmd`. If that is enabled `customCmdOn` / `customCmdOff` are used instead of CEC. The strings are preset to `vcgencmd display_power 1/0` so it's more or less a drop-in replacement. This enables more flexibility for the TV on/off command. In my case I needed to use `xset dpms force on/off` for my system. This is now possible.